### PR TITLE
recreate DB command

### DIFF
--- a/sql_cleanup.drush.inc
+++ b/sql_cleanup.drush.inc
@@ -12,6 +12,14 @@ function sql_cleanup_drush_command() {
       'db-su-pw' => 'Password for the "db-su" account.',
     ),
   );
+  $items['sql-create-database'] = array(
+    'description' => 'Create the sites database without any grants, unlike core drush.',
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,
+    'options' => array(
+      'db-su' => 'Account to use when dropping the DB.',
+      'db-su-pw' => 'Password for the "db-su" account.',
+    ),
+  );
   return $items;
 }
 
@@ -28,6 +36,25 @@ function drush_sql_cleanup_sql_drop_database() {
 
   $sql[] = sprintf('DROP DATABASE %s;', $db_spec['database']);
   $sql[] = 'FLUSH PRIVILEGES;';
+  $sql = implode(' ', $sql);
+
+  $db_su = drush_sql_su($db_spec);
+  return _drush_sql_query($sql, $db_su);
+}
+
+
+/**
+ * SQL Create Database command callback.
+ */
+function drush_sql_cleanup_sql_create_database() {
+  if (!drush_confirm(dt('Do you really want to continue?'))) {
+    return drush_user_abort();
+  }
+
+  $db_spec = _drush_sql_get_db_spec();
+
+  $sql[] = sprintf('DROP DATABASE IF EXISTS %s;', $db_spec['database']);
+  $sql[] = sprintf('CREATE DATABASE %s /*!40100 DEFAULT CHARACTER SET utf8 */;', $db_spec['database']);
   $sql = implode(' ', $sql);
 
   $db_su = drush_sql_su($db_spec);


### PR DESCRIPTION
Drush, by default, will try to make a GRANT for each DB it creates:
http://drupalcontrib.org/api/drupal/contributions%21drush%21commands%21sql%21sql.drush.inc/function/drush_sql_build_createdb_sql/7

We dont necessarily want that; for a PR system with a wildcard grant (`GRANT ALL ON drupal_site_pr_%.*....`) we do not need the extra grants (something else to drop later).

This provides a simple "drop and create" dush command.
